### PR TITLE
Aligning GPS parsing code in server to fhr code

### DIFF
--- a/qnx/merge-in-pieces/ros6/server/coordination_handler.c
+++ b/qnx/merge-in-pieces/ros6/server/coordination_handler.c
@@ -13,7 +13,7 @@ extern pthread_mutex_t coord_lock;
 extern int *trigger_state_pointer; //0-no activity,1-pre-trigger, 2-triggering 
 extern int *ready_state_pointer; //0-no cntrolprograms ready,1-some controlprograms ready, 2-all controlprograms ready 
 extern int *ready_count_pointer;
-extern int *trigger_type_pointer;  //0-strict controlprogram ready  1-elasped software time  2-external gps event 
+extern int trigger_type;  //0-strict controlprogram ready  1-elasped software time  2-external gps event
 extern int txread[MAX_RADARS];
 extern int verbose;
 extern int gpssock;
@@ -27,14 +27,13 @@ void *coordination_handler(struct ControlProgram *control_program)
    int gpssecond,gpsnsecond;
    struct DriverMsg msg;
    struct ControlProgram *cprog;
-   int ready_state,trigger_state,trigger_type,ready_count;
+   int ready_state,trigger_state,ready_count;
    struct timeval t0,t1,t2,t3,t4,t5,t6;
    unsigned long elapsed;
    if(verbose > 1 ) gettimeofday(&t0,NULL);
    pthread_mutex_lock(&coord_lock); //lock the global structures
 
    ready_state=*ready_state_pointer;
-   trigger_type=*trigger_type_pointer;
    trigger_state=*trigger_state_pointer;
    ready_count=*ready_count_pointer;
    if (control_program->active==1) {

--- a/qnx/merge-in-pieces/ros6/server/main.c
+++ b/qnx/merge-in-pieces/ros6/server/main.c
@@ -54,7 +54,8 @@ pthread_t status_thread=NULL,timeout_thread=NULL,log_thread=NULL;
 /* State Global Variables */
 dictionary *Site_INI;
 void *radar_channels[MAX_RADARS*MAX_CHANNELS];
-int *trigger_state_pointer,*trigger_type_pointer;
+/*int *trigger_state_pointer,*trigger_type_pointer; */
+int *trigger_state_pointer, trigger_type;
 int *ready_state_pointer,*ready_count_pointer;
 struct tx_status txstatus[MAX_RADARS];
 int txread[MAX_RADARS];
@@ -259,11 +260,11 @@ int main()
   ready_state_pointer=malloc(sizeof(int));
   ready_count_pointer=malloc(sizeof(int));
   trigger_state_pointer=malloc(sizeof(int));
-  trigger_type_pointer=malloc(sizeof(int));
+  /*trigger_type_pointer=malloc(sizeof(int)); */
   *ready_state_pointer=0; //no control programs ready
   *ready_count_pointer=0; //no control programs ready
   *trigger_state_pointer=0; //pre-trigger state
-  *trigger_type_pointer=0; //strict control program ready trigger type
+  trigger_type=0; //strict control program ready trigger type
   for(i=0;i<MAX_RADARS*MAX_CHANNELS;i++) {
     radar_channels[i]=NULL ;
   }

--- a/qnx/merge-in-pieces/ros6/server/settings_handler.c
+++ b/qnx/merge-in-pieces/ros6/server/settings_handler.c
@@ -12,6 +12,8 @@
 extern int verbose;
 extern pthread_mutex_t settings_lock;
 extern dictionary *Site_INI;
+extern int trigger_type;
+extern int32 gpsrate;
 
 
 void *settings_parse_ini_file(struct SiteSettings *ros_settings) {

--- a/qnx/merge-in-pieces/ros6/server/settings_handler.c
+++ b/qnx/merge-in-pieces/ros6/server/settings_handler.c
@@ -39,6 +39,25 @@ void *settings_parse_ini_file(struct SiteSettings *ros_settings) {
      sprintf(ros_settings->beam_table_1,iniparser_getstring(Site_INI,"beam_lookup_table:beam_table_1",""));
      sprintf(ros_settings->beam_table_2,iniparser_getstring(Site_INI,"beam_lookup_table:beam_table_2",""));
 
+     /* GPS trigger parsing section */
+     trigger_type=iniparser_getint(Site_INI,"site_settings:trigger_type",0);
+     fprintf(stdout, "Trigger_type: %d\n", trigger_type);
+     switch(trigger_type) {
+        case 0:
+            gpsrate=0;
+            gpsrate=iniparser_getint(Site_INI,"gps:trigger_rate",GPS_DEFAULT_TRIGRATE);
+            fprintf(stdout,"GPSrate: %d\n",gpsrate);
+            break;
+        case 1:
+        case 2:
+            gpsrate=iniparser_getint(Site_INI,"gps:trigger_rate",GPS_DEFAULT_TRIGRATE);
+            fprintf(stdout,"GPSrate: %d\n",gpsrate);
+            break;
+        default;
+            break;
+
+     }
+
      sprintf(ros_settings->name,"%s",iniparser_getstring(Site_INI,"site_settings:name",SITE_NAME));
      sprintf(entry_value,"%s",iniparser_getstring(Site_INI,"beam_lookup_table:use_table","ERROR"));
      printf("beam_lookup: %s\n",entry_value);


### PR DESCRIPTION
@sshepherd, here's the changes in the `ros/server/` code that should parse the ini file as well as other places in the `server` source code.  These were mostly changing pointers to variables outside of the `settings_handler.c` file.  There is one place I found where the global variable name is different between the two, but I've just left that as a note for now as changing that variable name might mean changing lots more than just the `server` code.

Feel free to merge this in if you think the changes are good.  Then do a git pull on your git repo on the linux and copy the files over to the QNX.