### PR TITLE
Beam syncing code for cv

### DIFF
--- a/linux/rst/usr/codebase/superdarn/src.bin/os/cp/normalscan.1.7/normalscan.c
+++ b/linux/rst/usr/codebase/superdarn/src.bin/os/cp/normalscan.1.7/normalscan.c
@@ -150,6 +150,11 @@ int main(int argc,char *argv[]) {
 	int bufus=0;    /*   been set to 3.0s to account for what???            */
 	unsigned char hlp=0;
 
+  /* Flag and variabels to sync beam soundings */
+  int bm_sync=0;
+  int bmsc=6;
+  int bmus=0;
+
 	if (debug) {
 		printf("Size of int %ld\n",sizeof(int));
 		printf("Size of long %ld\n",sizeof(long));
@@ -199,6 +204,10 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt, "eb",     'i', &ebm);
 	OptionAdd(&opt, "fixfrq", 'i', &fixfrq);   /* fix the transmit frequency */
 	OptionAdd(&opt, "-help",  'x', &hlp);      /* just dump some parameters */
+  OptionAdd(&opt, "bm_sync", 'x', &bm_sync);   /* flag to enable beam sync */
+  OptionAdd(&opt, "bmsc",   'i', &bmsc);       /* length of beam sync period, seconds */
+  OptionAdd(&opt, "bmus",   'i', &bmus);       /* length of beam sync period, microsec */
+
 
 	/* process the commandline; need this for setting errlog port */
   arg=OptionProcess(1,argc,argv,&opt,NULL);  
@@ -421,6 +430,11 @@ int main(int argc,char *argv[]) {
       if (bmnum==ebm) break;
       if (backward) bmnum--;
       else bmnum++;
+
+      if (bm_sync==1){
+        Errlog(errlog.sock,progname,"Syncing to beam timing");
+        SiteEndScan(bmsc,bmus);
+      }
 
     } while (1);
 


### PR DESCRIPTION
@sshepherd, I tested this additional code on fhr between 435 and 5 on 20191128 and see the timing's coming out pretty good.  There's some wiggle on the start of the beam sounding that I haven't quantified yet, but it's not an iterative delay like we're experiencing now.

I don't see any of the rxonly code for changing the cpid here, so I wouldn't suggest merging this until you've pushed changes from the radar back to this repo. (Something you should do sooner than later if you'd like to have a backup for your code)  At least you can see the changes that you'd need to make and where from this pull request.  You should be able to test this out during common time as it doesn't have break CT guidelines/rules if you keep the integration and beam times down to do a full scan. 