### PR TITLE
Changing the sample determination in SiteFh*Integrate to use total_samples

### DIFF
--- a/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhe.1.0/src/site.c
+++ b/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhe.1.0/src/site.c
@@ -1004,7 +1004,7 @@ usleep(usecs);
     /* copy samples here */
 
       seqoff[nave]=iqsze/2;/*Sequence offset in 16bit units */
-      seqsze[nave]=dprm.samples*2*2; /* Sequence length in 16bit units */
+      seqsze[nave]=total_samples*2*2; /* Sequence length in 16bit units */
 
       if(seqbadtr[nave].start!=NULL)  free(seqbadtr[nave].start);
       if(seqbadtr[nave].length!=NULL) free(seqbadtr[nave].length);
@@ -1028,15 +1028,15 @@ usleep(usecs);
 
       dest = (void *)(samples);  /* look iqoff bytes into samples area */
       dest+=iqoff;
-      if ((iqoff+dprm.samples*2*sizeof(uint32) )<IQBUFSIZE) {
-        memmove(dest,rdata.main,dprm.samples*sizeof(uint32));
-        dest += dprm.samples*sizeof(uint32); /* skip ahead number of samples * 32 bit per sample to account for rdata.main*/
-        memmove(dest,rdata.back,dprm.samples*sizeof(uint32));
+      if ((iqoff+total_samples*2*sizeof(uint32) )<IQBUFSIZE) {
+        memmove(dest,rdata.main,total_samples*sizeof(uint32));
+        dest += total_samples*sizeof(uint32); /* skip ahead number of samples * 32 bit per sample to account for rdata.main*/
+        memmove(dest,rdata.back,total_samples*sizeof(uint32));
       } else {
         fprintf(stderr,"IQ Buffer overrun in SiteFheIntegrate\n");
         fflush(stderr);
       }
-      iqsze+=dprm.samples*sizeof(uint32)*2;  /*  Total of number bytes so far copied into samples array */
+      iqsze+=total_samples*sizeof(uint32)*2;  /*  Total of number bytes so far copied into samples array */
       if (debug) {
         fprintf(stderr,"FHE seq %d :: ioff: %8d\n",nave,iqoff);
         fprintf(stderr,"FHE seq %d :: rdata.main 16bit :\n",nave);
@@ -1052,7 +1052,7 @@ usleep(usecs);
         fprintf(stderr,"FHE seq %d :: rdata.back 16bit 8-11: %8d %8d %8d %8d\n",nave,
            ((int16 *)rdata.back)[8],((int16 *)rdata.back)[9],
            ((int16 *)rdata.back)[10],((int16 *)rdata.back)[11]);
-        dest += dprm.samples*4;
+        dest += total_samples*4;
         fprintf(stderr,"FHE seq %d :: samples    16bit 8-11: %8d %8d %8d %8d\n",nave,
            ((int16 *)dest)[8],((int16 *)dest)[9],
            ((int16 *)dest)[10],((int16 *)dest)[11]);
@@ -1078,14 +1078,14 @@ usleep(usecs);
         if (debug)
         fprintf(stderr,"FHE seq %d :: ACFCalculate acf\n",nave);
         ACFCalculate(&tsgprm,(int16 *) dest,rngoff,skpnum!=0,
-          roff,ioff,mplgs,lagtable,acfd,ACF_PART,2*dprm.samples,badrng,seqatten[nave]*atstp,NULL);
+          roff,ioff,mplgs,lagtable,acfd,ACF_PART,2*total_samples,badrng,seqatten[nave]*atstp,NULL);
         if (xcf ==1 ){
         if (debug)
         fprintf(stderr,"FHE seq %d :: rngoff %d rxchn %d\n",nave,rngoff,rxchn);
         if (debug)
           fprintf(stderr,"FHE seq %d :: ACFCalculate xcf\n",nave);
           ACFCalculate(&tsgprm,(int16 *) dest,rngoff,skpnum!=0,
-                    roff,ioff,mplgs,lagtable,xcfd,XCF_PART,2*dprm.samples,badrng,seqatten[nave]*atstp,NULL);
+                    roff,ioff,mplgs,lagtable,xcfd,XCF_PART,2*total_samples,badrng,seqatten[nave]*atstp,NULL);
         }
         if ((nave>0) && (seqatten[nave] !=seqatten[nave])) {
         if (debug)

--- a/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhe.1.0/src/site.c
+++ b/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhe.1.0/src/site.c
@@ -437,7 +437,7 @@ int SiteFheFCLR(int stfreq,int edfreq) {
   TCPIPMsgRecv(sock,&noise, sizeof(float));
   TCPIPMsgRecv(sock,&rmsg, sizeof(struct ROSMsg));
   if (debug) {
-    fprintf(stderr,"REQUEST_ASSIGNED_FREQ:type=%c\n",rmsg.status);
+    fprintf(stderr,"REQUEST_ASSIGNED_FREQ:type=%c\n",rmsg.type);
     fprintf(stderr,"REQUEST_ASSIGNED_FREQ:status=%d\n",rmsg.status);
   }
 

--- a/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhw.1.0/src/site.c
+++ b/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhw.1.0/src/site.c
@@ -437,7 +437,7 @@ int SiteFhwFCLR(int stfreq,int edfreq) {
   TCPIPMsgRecv(sock,&noise, sizeof(float));
   TCPIPMsgRecv(sock,&rmsg, sizeof(struct ROSMsg));
   if (debug) {
-    fprintf(stderr,"REQUEST_ASSIGNED_FREQ:type=%c\n",rmsg.status);
+    fprintf(stderr,"REQUEST_ASSIGNED_FREQ:type=%c\n",rmsg.type);
     fprintf(stderr,"REQUEST_ASSIGNED_FREQ:status=%d\n",rmsg.status);
   }
 

--- a/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhw.1.0/src/site.c
+++ b/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.fhw.1.0/src/site.c
@@ -1002,7 +1002,7 @@ usleep(usecs);
     /* copy samples here */
 
       seqoff[nave]=iqsze/2;/*Sequence offset in 16bit units */
-      seqsze[nave]=dprm.samples*2*2; /* Sequence length in 16bit units */
+      seqsze[nave]=total_samples*2*2; /* Sequence length in 16bit units */
 
       if(seqbadtr[nave].start!=NULL)  free(seqbadtr[nave].start);
       if(seqbadtr[nave].length!=NULL) free(seqbadtr[nave].length);
@@ -1026,15 +1026,15 @@ usleep(usecs);
 
       dest = (void *)(samples);  /* look iqoff bytes into samples area */
       dest+=iqoff;
-      if ((iqoff+dprm.samples*2*sizeof(uint32) )<IQBUFSIZE) {
-        memmove(dest,rdata.main,dprm.samples*sizeof(uint32));
-        dest += dprm.samples*sizeof(uint32); /* skip ahead number of samples * 32 bit per sample to account for rdata.main*/
-        memmove(dest,rdata.back,dprm.samples*sizeof(uint32));
+      if ((iqoff+total_samples*2*sizeof(uint32) )<IQBUFSIZE) {
+        memmove(dest,rdata.main,total_samples*sizeof(uint32));
+        dest += total_samples*sizeof(uint32); /* skip ahead number of samples * 32 bit per sample to account for rdata.main*/
+        memmove(dest,rdata.back,total_samples*sizeof(uint32));
       } else {
         fprintf(stderr,"IQ Buffer overrun in SiteFhwIntegrate\n");
         fflush(stderr);
       }
-      iqsze+=dprm.samples*sizeof(uint32)*2;  /*  Total of number bytes so far copied into samples array */
+      iqsze+=total_samples*sizeof(uint32)*2;  /*  Total of number bytes so far copied into samples array */
       if (debug) {
         fprintf(stderr,"FHW seq %d :: ioff: %8d\n",nave,iqoff);
         fprintf(stderr,"FHW seq %d :: rdata.main 16bit :\n",nave);
@@ -1050,7 +1050,7 @@ usleep(usecs);
         fprintf(stderr,"FHW seq %d :: rdata.back 16bit 8-11: %8d %8d %8d %8d\n",nave,
            ((int16 *)rdata.back)[8],((int16 *)rdata.back)[9],
            ((int16 *)rdata.back)[10],((int16 *)rdata.back)[11]);
-        dest += dprm.samples*4;
+        dest += total_samples*4;
         fprintf(stderr,"FHW seq %d :: samples    16bit 8-11: %8d %8d %8d %8d\n",nave,
            ((int16 *)dest)[8],((int16 *)dest)[9],
            ((int16 *)dest)[10],((int16 *)dest)[11]);


### PR DESCRIPTION
This is an attempt to bring the `SiteFheIntegrate` and `SiteFhwIntegrate` routines in line with the Christmas Valley equivalents.  The issue appears to be that using `dprm.samples` to set the `iqsze` and `seqsze` values causes the IQ structure in the iqdat file to point to out-of-bound locations in the resulting sample array.  This is because there are an extra 11 samples per sequence associated with the `dprm.samples` value (nbaud+10) compared to the `total_samples` value calculated from the timing sequence.